### PR TITLE
FOUND-2760 GitHub action for publishing

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,16 @@ gradlePlugin {
 publishing {
     repositories {
         mavenLocal()
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/eurofunk/sbom-license-plugin")
+                credentials {
+                    username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                    password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                }
+            }
+        }
     }
 }
 

--- a/docs/how-to-create-github-release.md
+++ b/docs/how-to-create-github-release.md
@@ -1,0 +1,60 @@
+# How to Create a Release in GitHub
+
+## Steps
+
+1. ### Open the [GitHub Releases Page](https://github.com/Eurofunk/sbom-license-plugin/releases).
+
+2. ### Click “Draft a New Release”
+   This opens the release creation form.
+
+3. ### Fill in the Release Details
+
+    - **Tag version:**
+      Use an existing tag or create a new one (e.g., `v1.0.0`).
+      If creating a new tag, choose the target branch (usually `main` or `release`).
+
+    - **Release title:**
+      A short, descriptive title (e.g., _"Initial Release"_).
+
+    - **Description:**
+      Write release notes. Include:
+        - New features
+        - Bug fixes
+        - Breaking changes
+        - Upgrade instructions
+        - Attach binaries or assets (optional):
+
+   Pre-release checkbox:
+    - Check this if the release is not stable (e.g., alpha, beta).
+
+4. ### Publish the Release
+   Click **"Publish release"** to make it live.
+
+Read
+more: [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#about-release-management).
+
+---
+Once a release is published, the [gradle-publish.yml](../.github/workflows/gradle-publish.yml) workflow is executed
+automatically.
+It builds and publishes the artifacts to the repositories defined in [build.gradle.kts](../build.gradle.kts):
+
+```kotlin
+publishing {
+    repositories {
+        mavenLocal()
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/eurofunk/sbom-license-plugin")
+                credentials {
+                    username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                    password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                }
+            }
+        }
+    }
+}
+```
+
+By default, the published packages can be found
+on the [GitHub Packages](https://github.com/orgs/Eurofunk/packages?repo_name=sbom-license-plugin) page.


### PR DESCRIPTION
Created a simple workflow using the [Publishing-using-gradle](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle) GitHub action.

The workflow is executed once a GitHub Release is created. It uses `./gradlew publish` command, which does publishing in the repository configured here: https://github.com/Eurofunk/sbom-license-plugin/blob/4fb149323587b2c094f9ee4380757c689f760124/build.gradle.kts#L47-L56

The workflow sets`${{ github.actor }}` variable value for the **USERNAME**, and `${{ secrets.GITHUB_TOKEN }}` for the **TOKEN**.

See also: 
- [Example using Kotlin DSL for a single package in the same repository](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#example-using-kotlin-dsl-for-a-single-package-in-the-same-repository).
- [Using the GITHUB_TOKEN in a workflow](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)